### PR TITLE
feat(smtp): add contactPixelTrackingConsent to sendTransacEmail recipients

### DIFF
--- a/src/api/resources/transactionalEmails/client/requests/SendTransacEmailRequest.ts
+++ b/src/api/resources/transactionalEmails/client/requests/SendTransacEmailRequest.ts
@@ -86,6 +86,8 @@ export namespace SendTransacEmailRequest {
 
     export namespace Bcc {
         export interface Item {
+            /** Consent of the recipient in bcc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+            contactPixelTrackingConsent?: boolean | undefined;
             /** BCC recipient email address */
             email: string;
             /** Display name of the BCC recipient. Maximum length is 70 characters. */
@@ -97,6 +99,8 @@ export namespace SendTransacEmailRequest {
 
     export namespace Cc {
         export interface Item {
+            /** Consent of the recipient in cc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+            contactPixelTrackingConsent?: boolean | undefined;
             /** CC recipient email address */
             email: string;
             /** Display name of the CC recipient. Maximum length is 70 characters. */
@@ -131,6 +135,8 @@ export namespace SendTransacEmailRequest {
 
             export namespace Bcc {
                 export interface Item {
+                    /** Consent of the recipient in bcc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+                    contactPixelTrackingConsent?: boolean | undefined;
                     /** BCC recipient email address */
                     email: string;
                     /** Display name of the BCC recipient. Maximum length is 70 characters. */
@@ -142,6 +148,8 @@ export namespace SendTransacEmailRequest {
 
             export namespace Cc {
                 export interface Item {
+                    /** Consent of the recipient in cc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+                    contactPixelTrackingConsent?: boolean | undefined;
                     /** CC recipient email address */
                     email: string;
                     /** Display name of the CC recipient. Maximum length is 70 characters. */
@@ -163,6 +171,8 @@ export namespace SendTransacEmailRequest {
 
             export namespace To {
                 export interface Item {
+                    /** Consent of the recipient for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+                    contactPixelTrackingConsent?: boolean | undefined;
                     /** Email address of the recipient */
                     email: string;
                     /** Display name of the recipient. Maximum length is 70 characters. */
@@ -198,6 +208,8 @@ export namespace SendTransacEmailRequest {
 
     export namespace To {
         export interface Item {
+            /** Consent of the recipient for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account. */
+            contactPixelTrackingConsent?: boolean | undefined;
             /** Email address of the recipient */
             email: string;
             /** Display name of the recipient. Maximum length is 70 characters. */


### PR DESCRIPTION
Adds the per-recipient `contactPixelTrackingConsent` boolean to all six inlined recipient shapes of `POST /v3/smtp/email` in `SendTransacEmailRequest.ts`:

- `SendTransacEmailRequest.To.Item` / `.Cc.Item` / `.Bcc.Item`
- `SendTransacEmailRequest.MessageVersions.Item.To.Item` / `.Cc.Item` / `.Bcc.Item`

## This is a typing-only change

There is no `src/serialization` layer for this endpoint and `Client.ts` does `body: request` straight to `core.fetcher`, so **the field already reaches the wire on published 6.0.2** for untyped JS callers. Only TypeScript users were blocked — they could not set it without an `as any` cast. Nothing about the request payload changes.

## Verified

- `pnpm build` (tsc cjs + esm) clean; `vitest run` 57 files / 1431 tests passed, unchanged vs. baseline
- `biome format:check` + lint clean on the edited file
- `tsc --strict` snippet setting the field on `to`/`cc`/`bcc` and inside `messageVersions` with **no casts** compiles; `"banana"` is a type error
- local capture server: `true` / `false` land per recipient, key **entirely absent** (not `null`, not `false`) when omitted — tri-state survives
- real sends to `api.brevo.com/v3` on prod test account 3143293: `201`, delivered

## Why this is hand-written

This repo is Fern-generated and has not been regenerated since **2026-07-03**, so the field never appeared in the published SDK even though the spec has carried it for weeks. Rather than keep waiting on a `fern generate` run, this is a hand-written stopgap that matches what the generator would emit. **The next `fern generate` will overwrite these files — that is expected and fine**, because the regenerated output contains the same field. **No version bump**: Fern owns versioning.

Six edits, not four: Fern inlines separate recipient copies for `messageVersions`, matching the 6 occurrences in the spec.

## Description wording covers clicks too

Per-contact consent gates **click** links as well as the open pixel — `an=1` is stamped at send time by DTSL/sendmail-personaliser#1231 and consumed by DTSL/redirection#2384, in production since 2026-08-03. The descriptions here reflect that. The matching spec wording update is DTSL/public-api#5895 (legacy client spec + OpenAPI bundle + generated v3, all in one PR). Until it merges this text is ahead of the published spec.

## Related

- Spec: DTSL/public-api#5895 (legacy client spec + OpenAPI bundle + generated v3), earlier bundle PRs #5885 / #5890 / #5892 / #5893, DTSL/public-developer-portal#94
- Sibling SDK PRs: getbrevo/brevo-java#27, getbrevo/brevo-csharp#19, getbrevo/brevo-ruby#17, getbrevo/brevo-go#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)