### PR TITLE
docs(readme): fix Error Handling import to use Brevo namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ const brevo = new BrevoClient({
 The SDK throws specific error types based on HTTP status codes.
 
 ```typescript
-import { BrevoError, UnauthorizedError, TooManyRequestsError } from '@getbrevo/brevo';
+import { Brevo, BrevoError } from '@getbrevo/brevo';
 
 try {
   await brevo.transactionalEmails.sendTransacEmail({...});
 } catch (err) {
-  if (err instanceof UnauthorizedError) {
+  if (err instanceof Brevo.UnauthorizedError) {
     console.error('Invalid API key');
-  } else if (err instanceof TooManyRequestsError) {
+  } else if (err instanceof Brevo.TooManyRequestsError) {
     const retryAfter = err.rawResponse.headers['retry-after'];
     console.error(`Rate limited. Retry after ${retryAfter} seconds`);
   } else if (err instanceof BrevoError) {
@@ -83,14 +83,16 @@ try {
 }
 ```
 
+Typed subclasses are namespaced under `Brevo` (e.g. `Brevo.UnauthorizedError`) — only `BrevoError` and `BrevoTimeoutError` are top-level exports.
+
 **Error Types:**
-- `400` - `BadRequestError`
-- `401` - `UnauthorizedError`
-- `403` - `ForbiddenError`
-- `404` - `NotFoundError`
-- `422` - `UnprocessableEntityError`
-- `429` - `TooManyRequestsError`
-- `500+` - `InternalServerError`
+- `400` - `Brevo.BadRequestError`
+- `401` - `Brevo.UnauthorizedError`
+- `403` - `Brevo.ForbiddenError`
+- `404` - `Brevo.NotFoundError`
+- `422` - `Brevo.UnprocessableEntityError`
+- `429` - `Brevo.TooManyRequestsError`
+- `500+` - `Brevo.InternalServerError`
 
 <details>
 <summary>Error properties</summary>


### PR DESCRIPTION
## What
The README's Error Handling example imports `UnauthorizedError` and `TooManyRequestsError` as bare top-level names:

```ts
import { BrevoError, UnauthorizedError, TooManyRequestsError } from '@getbrevo/brevo';
```

That doesn't compile — TS2305, no exported member.

## Why
`generators.yml` sets `namespaceExport: Brevo` for the TypeScript SDK, so `src/index.ts` re-exports the whole API surface (including these per-status error subclasses) under a `Brevo` namespace:

```ts
export * as Brevo from "./api/index.js";
export { BrevoError, BrevoTimeoutError } from "./errors/index.js";
```

Only `BrevoError` / `BrevoTimeoutError` (and `BrevoClient`) are genuinely top-level. The other typed subclasses (`UnauthorizedError`, `TooManyRequestsError`, `BadRequestError`, etc.) are only reachable as `Brevo.UnauthorizedError`, etc.

## Fix
Updates the example and the "Error Types" list to use the `Brevo.*` qualified names, matching how the SDK is actually generated. Same fix applied to the corresponding page on the public docs site (developers.brevo.com).

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
